### PR TITLE
chore: improve developer experience

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,10 @@ members = [".", "lib/win-gsmtc", "lib/win-wrapper"]
 
 [features]
 single-executable = []
-default = ["single-executable"]
+# When enabled, the executable will be compiled with the WINDOWS subsytem
+# over the default CONSOLE subsystem.
+win32-executable = []
+default = ["single-executable", "win32-executable"]
 
 [[bin]]
 name = "current-song2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 members = [".", "lib/win-gsmtc", "lib/win-wrapper"]
 
 [features]
+# When enabled, the overlay will be bundled into the executable.
 single-executable = []
 # When enabled, the executable will be compiled with the WINDOWS subsytem
 # over the default CONSOLE subsystem.

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ npm i -g pnpm
    cargo build -r --locked
    ```
 
-   This will build the executable in release mode. To build in debug mode, leave out the `-r`. For local development, it's useful to not bundle the overlay inside the executable and be able to stop the app with <kbd>CTRL</kbd> + <kbd>C</kbd>. To achieve this, add `--no-default-features` (this will disable the `single-executable` and `win32-executable` features).
+   This will build the executable in release mode. To build in debug mode, leave out the `-r`. For local development, it's useful to not bundle the overlay inside the executable and be able to stop the app with <kbd>CTRL</kbd> + <kbd>C</kbd>. To achieve this, add `--no-default-features` (this will disable the `single-executable` and `win32-executable` features). Furthermore, it's useful to run the app in the project-directory (instead of `target/{debug,release}`). To do this, add `--current-dir` when running. A good command-line for development is: `cargo r --no-default-features -- --current-dir`.
 
 ## Planned Features
 

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ npm i -g pnpm
    cargo build -r --locked
    ```
 
-   This will build the executable in release mode. To build in debug mode, leave out the `-r`. For local development, it's useful to not bundle the overlay inside the executable. To achieve this, add `--no-default-features` (this will disable the `single-executable` feature).
+   This will build the executable in release mode. To build in debug mode, leave out the `-r`. For local development, it's useful to not bundle the overlay inside the executable and be able to stop the app with <kbd>CTRL</kbd> + <kbd>C</kbd>. To achieve this, add `--no-default-features` (this will disable the `single-executable` and `win32-executable` features).
 
 ## Planned Features
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![windows_subsystem = "windows"]
+#![cfg_attr(feature = "win32-executable", windows_subsystem = "windows")]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
 #![allow(clippy::module_name_repetitions)]

--- a/themes/README.md
+++ b/themes/README.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-- Download the css file
+- Download the CSS file
 - **Either:** save the file as `theme.css` in the current-song directory **or** set the `custom_theme_path` config
   setting to your theme.
 

--- a/themes/README.md
+++ b/themes/README.md
@@ -10,14 +10,14 @@
 
 ### [`blurred-bg.css`](blurred-bg.css)
 
-![example](https://i.imgur.com/cWXBunf.png)
+![Example of `blurred-bg-css`](https://user-images.githubusercontent.com/19953266/229280357-7bc3ff2e-0be4-4ecf-9ce0-f696677c5edb.png)
 
 ### [`blurred-bg-slide.css`](blurred-bg-slide.css)
 
 Essentially the same as [`blurred-bg.css`](blurred-bg.css), except that the background image is animated.
 
-![example](https://i.imgur.com/cWXBunf.png)
+![Example of `blurred-bg-slide.css`](https://user-images.githubusercontent.com/19953266/229280343-b2169dd0-4632-48a7-916f-3f6209da49a7.png)
 
 ### [`transparent.css`](transparent.css)
 
-![example](https://i.imgur.com/QdbJGoB.png)
+![Example of `transparent.css`](https://user-images.githubusercontent.com/19953266/229280305-f45d9f1d-85a1-4b9d-9e4f-8b2e22a1aaf4.png)


### PR DESCRIPTION
* Adds `win32-executable` feature to choose the windows-subsystem
* Adds documentation on `--current-dir`
* Hosts images in `themes/` on GitHub