### PR TITLE
ci: Add Artifact-Hashes to Body

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,9 +113,23 @@ jobs:
         with:
           path: artifacts
 
+      - name: Hash Files
+        run: |
+          echo "### Hashes" > body.txt
+          echo "| File | Hash |" >> body.txt
+          echo "|---|---|" >> body.txt
+          for file in $(find artifacts); 
+          do 
+            if [ ! -d "$file" ]; then
+              echo "| $(basename -- "$file") | $(sha256sum "$file" | cut -d " " -f 1) |" >> body.txt;
+            fi;
+          done
+        shell: bash
+
       - uses: ncipollo/release-action@v1
         with:
           artifacts: 'artifacts/**/*'
           token: ${{ secrets.GITHUB_TOKEN }}
           generateReleaseNotes: true
+          bodyFile: body.txt
           prerelease: ${{ env.ext_release == '0' }}


### PR DESCRIPTION
This is (partially) addressing the missing hashes, as mentioned in https://github.com/Nerixyz/current-song2/issues/306#issuecomment-1567311572. However, one still can't completely verify that the body of a release hasn't been altered.