### PR TITLE
fix: Marquee options parsing incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ When releasing a new version:
 ### Fixed
 
 - Missing user-scripts would break the overlay in dev mode (`pnpm dev`).
+- The marquee effect would not work in Chromium < 103.
 
 ## [v0.1.0-alpha.9] - 2023-08-04
 

--- a/js/client/src/index.ts
+++ b/js/client/src/index.ts
@@ -31,13 +31,13 @@ function wrapMarqueeElements(
   subtitleEl: HTMLElement,
 ): MarqueeEl {
   const style = getComputedStyle(root);
-  const useIt = style.getPropertyValue('--use-marquee') === 'true';
+  const useIt = style.getPropertyValue('--use-marquee').trim() === 'true';
   if (!useIt) {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     return { pause() {}, reset() {}, start() {} };
   }
   const opt = (name: string, defaultValue: number) => {
-    const parsed = parseInt(style.getPropertyValue(name));
+    const parsed = parseFloat(style.getPropertyValue(name).trim());
     return Number.isNaN(parsed) ? defaultValue : parsed;
   };
   const opts: MarqueeOptions = {


### PR DESCRIPTION
Fixes #357. I have no clue why that worked in the first place.