### PR TITLE
feat(win-gsmtc): use `Duration` instead of `i64`

### DIFF
--- a/lib/win-gsmtc/src/conversion.rs
+++ b/lib/win-gsmtc/src/conversion.rs
@@ -52,9 +52,9 @@ impl TryFrom<GlobalSystemMediaTransportControlsSessionTimelineProperties> for Ti
         value: GlobalSystemMediaTransportControlsSessionTimelineProperties,
     ) -> Result<Self, Self::Error> {
         Ok(Self {
-            start: value.StartTime()?.Duration,
-            end: value.EndTime()?.Duration,
-            position: value.Position()?.Duration,
+            start: value.StartTime()?.into(),
+            end: value.EndTime()?.into(),
+            position: value.Position()?.into(),
             last_updated_at_ms: filetime_to_unix_ms(value.LastUpdatedTime()?.UniversalTime),
         })
     }

--- a/lib/win-gsmtc/src/model.rs
+++ b/lib/win-gsmtc/src/model.rs
@@ -1,5 +1,7 @@
-use std::fmt::{Debug, Formatter};
-use std::time::Duration;
+use std::{
+    fmt::{Debug, Formatter},
+    time::Duration,
+};
 
 /// Represents a playback session from another app providing info about that session.
 ///

--- a/lib/win-gsmtc/src/model.rs
+++ b/lib/win-gsmtc/src/model.rs
@@ -1,4 +1,5 @@
 use std::fmt::{Debug, Formatter};
+use std::time::Duration;
 
 /// Represents a playback session from another app providing info about that session.
 ///
@@ -66,11 +67,11 @@ pub struct PlaybackModel {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TimelineModel {
     /// The starting timestamp of the current media item.
-    pub start: i64,
+    pub start: Duration,
     /// The end timestamp of the current media item.
-    pub end: i64,
+    pub end: Duration,
     /// The playback position, current as of [`last_updated_at_ms`](TimelineModel::last_updated_at_ms).
-    pub position: i64,
+    pub position: Duration,
     /// The UTC time at which the timeline properties were last updated.
     pub last_updated_at_ms: i64,
     // TODO: add {Max,Min}SeekTime

--- a/lib/win-gsmtc/src/session.rs
+++ b/lib/win-gsmtc/src/session.rs
@@ -185,7 +185,12 @@ fn timeline_actually_the_same(first: &Option<TimelineModel>, second: &TimelineMo
                     && first.end == second.end
                     && rough_eq(
                         second.last_updated_at_ms - first.last_updated_at_ms,
-                        (second.position - first.position) / 10_000,
+                        second
+                            .position
+                            .saturating_sub(first.position)
+                            .as_millis()
+                            .try_into()
+                            .unwrap_or_default(),
                     ))
         })
         .unwrap_or_default()

--- a/src/workers/gsmtc.rs
+++ b/src/workers/gsmtc.rs
@@ -151,10 +151,16 @@ fn convert_model(from: SessionModel, image: Option<ImageInfo>) -> ModuleState {
             timeline: timeline
                 .filter(|timeline| timeline.end > timeline.start && timeline.last_updated_at_ms > 0)
                 .map(|timeline| TimelineInfo {
-                    duration_ms: ((timeline.end - timeline.start) / 10_000)
+                    duration_ms: timeline
+                        .end
+                        .saturating_sub(timeline.start)
+                        .as_millis()
                         .try_into()
                         .unwrap_or_default(),
-                    progress_ms: ((timeline.position - timeline.start) / 10_000)
+                    progress_ms: timeline
+                        .position
+                        .saturating_sub(timeline.start)
+                        .as_millis()
                         .try_into()
                         .unwrap_or_default(),
                     ts: timeline.last_updated_at_ms.try_into().unwrap_or_default(),


### PR DESCRIPTION
Refactors the time fields from `i64` to `std::time::Duration`.