### PR TITLE
refactor(dbus): automatically discover services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ When releasing a new version:
 ### Added
 
 - Added the `use-raw-data` query parameter for the overlay. If it's present in the URL, no cleanup will be performed on the client (example: `http://localhost:48457/?use-raw-data`).
+- Linux: The dbus adapter now automatically discovers all `org.mpris.MediaPlayer2.*` services. If you previously ran an instance, you need to update your config and set `modules.dbus.destinations` to `["org.mpris.MediaPlayer2.*"]`.
+
+### Fixed
+
+- Linux: Local images (`file://`) are now loaded correctly.
 
 ## [v0.1.0-alpha.13] - 2024-06-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,6 +619,7 @@ dependencies = [
  "actix-web-actors",
  "actix-web-static-files",
  "anyhow",
+ "fast-glob",
  "futures",
  "lazy_static",
  "mpris-dbus",
@@ -635,6 +642,7 @@ dependencies = [
  "win-msgbox",
  "win-wrapper",
  "windows",
+ "zbus_names",
 ]
 
 [[package]]
@@ -751,6 +759,15 @@ checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
  "event-listener",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fast-glob"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eca69ef247d19faa15ac0156968637440824e5ff22baa5ee0cd35b2f7ea6a0f"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -1336,6 +1353,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "zbus",
+ "zbus_names",
 ]
 
 [[package]]
@@ -2728,12 +2746,13 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.0.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc27fbd3593ff015cef906527a2ec4115e2e3dbf6204a24d952ac4975c80614"
+checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
 dependencies = [
  "serde",
  "static_assertions",
+ "winnow 0.7.1",
  "zvariant",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ tracing-actix-web = "0.7"
 tracing-actix = "0.4"
 tracing-appender = "0.2"
 url = "2.5.4"
+fast-glob = "0.4.3"
 
 [target.'cfg(windows)'.dependencies]
 win-gsmtc = { path = "lib/win-gsmtc" }
@@ -62,6 +63,7 @@ win-msgbox = "0.2"
 
 [target.'cfg(unix)'.dependencies]
 mpris-dbus = { path = "lib/mpris-dbus" }
+zbus_names = "4.2.0"
 
 [build-dependencies]
 actix-web-static-files = "4.0"

--- a/lib/mpris-dbus/Cargo.toml
+++ b/lib/mpris-dbus/Cargo.toml
@@ -18,6 +18,7 @@ thiserror = "2"
 tokio = { version = "1.43", features = ["sync", "rt", "macros"] }
 tracing = "0.1"
 zbus = { version = "5.5", default-features = false, features = ["tokio"] }
+zbus_names = "4.2.0"
 
 [dev-dependencies]
 tokio = { version = "1.43", features = ["sync", "macros", "rt-multi-thread"] }

--- a/lib/mpris-dbus/src/discovery.rs
+++ b/lib/mpris-dbus/src/discovery.rs
@@ -1,0 +1,54 @@
+use futures::StreamExt;
+use zbus::Connection;
+
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum Error {
+    #[error("Failed to get DBus connection to the user message bus ({0})")]
+    GetConnection(zbus::Error),
+    #[error("Failed to setup the proxy ({0})")]
+    SetupProxy(zbus::Error),
+    #[error("Failed to listen to the name acquired stream ({0})")]
+    ListenNameAcquired(zbus::Error),
+    #[error("Failed to list names ({0})")]
+    ListNames(zbus::fdo::Error),
+}
+
+pub struct Listener {
+    conn: Connection,
+}
+
+impl Listener {
+    pub async fn new() -> Result<Self, Error> {
+        Ok(Self {
+            conn: Connection::session().await.map_err(Error::GetConnection)?,
+        })
+    }
+
+    pub async fn listen(
+        &self,
+    ) -> Result<impl futures::Stream<Item = zbus_names::BusName<'static>>, Error> {
+        let proxy = zbus::fdo::DBusProxy::new(&self.conn)
+            .await
+            .map_err(Error::SetupProxy)?;
+
+        let current = proxy.list_names().await.map_err(Error::ListNames)?;
+
+        Ok(
+            futures::stream::iter(current.into_iter().map(|it| it.into_inner())).chain(
+                proxy
+                    .receive_name_owner_changed()
+                    .await
+                    .map_err(Error::ListenNameAcquired)?
+                    .filter_map(|it| {
+                        std::future::ready(it.args().ok().and_then(|n| {
+                            if n.new_owner.is_some() {
+                                Some(n.name.into_owned())
+                            } else {
+                                None
+                            }
+                        }))
+                    }),
+            ),
+        )
+    }
+}

--- a/lib/mpris-dbus/src/interface.rs
+++ b/lib/mpris-dbus/src/interface.rs
@@ -26,7 +26,7 @@ pub enum LoopStatus {
     default_path = "/org/mpris/MediaPlayer2",
     gen_blocking = false
 )]
-pub trait SpotifyPlayer {
+pub trait MediaPlayer {
     // Methods
     fn next(&self) -> fdo::Result<()>;
     fn previous(&self) -> fdo::Result<()>;

--- a/lib/mpris-dbus/src/lib.rs
+++ b/lib/mpris-dbus/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg(unix)]
 
+pub mod discovery;
 pub mod interface;
 pub mod player;

--- a/lib/mpris-dbus/src/player/listener.rs
+++ b/lib/mpris-dbus/src/player/listener.rs
@@ -79,8 +79,7 @@ where
                 },
                 Some(owner) = owner_changed.next() => {
                     if owner.filter(|x| x.is_empty()).is_none() {
-                        state.status = PlaybackStatus::Stopped;
-                        send_or_break!(tx, state.clone());
+                        break;
                     }
                 },
                 else => break

--- a/lib/mpris-dbus/src/player/listener.rs
+++ b/lib/mpris-dbus/src/player/listener.rs
@@ -30,7 +30,7 @@ where
     D::Error: Into<zbus::Error>,
 {
     let connection = Connection::session().await.map_err(Error::GetConnection)?;
-    let proxy = SpotifyPlayerProxy::builder(&connection)
+    let proxy = MediaPlayerProxy::builder(&connection)
         .destination(dest)
         .map_err(Error::SetupProxy)?
         .build()
@@ -92,7 +92,7 @@ where
     Ok(rx)
 }
 
-async fn update_meta(proxy: &SpotifyPlayerProxy<'_>, state: &mut State) {
+async fn update_meta(proxy: &MediaPlayerProxy<'_>, state: &mut State) {
     let Ok(meta) = proxy
         .metadata()
         .await
@@ -127,7 +127,7 @@ async fn update_meta(proxy: &SpotifyPlayerProxy<'_>, state: &mut State) {
     update_position(proxy, state).await;
 }
 
-async fn update_position(proxy: &SpotifyPlayerProxy<'_>, state: &mut State) -> bool {
+async fn update_position(proxy: &MediaPlayerProxy<'_>, state: &mut State) -> bool {
     match proxy.position().await {
         Ok(p) => {
             state.timeline.position = p;

--- a/src/config.rs
+++ b/src/config.rs
@@ -173,7 +173,7 @@ cfg_unix! {
         fn default() -> Self {
             Self {
                 enabled: true,
-                destinations: vec!["org.mpris.MediaPlayer2.spotify".to_owned()],
+                destinations: vec!["org.mpris.MediaPlayer2.*".to_owned()],
             }
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,6 @@
 use crate::{cfg_unix, cfg_windows};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashSet,
     fs,
     path::{Path, PathBuf},
     sync::OnceLock,
@@ -114,6 +113,8 @@ impl Default for FileOutputConfig {
 }
 
 cfg_windows! {
+    use std::collections::HashSet;
+
     #[derive(Deserialize, Serialize, Debug, Clone)]
     #[serde(default)]
     pub struct GsmtcConfig {
@@ -204,6 +205,8 @@ lazy_static::lazy_static! {
                     if !crate::win_setup::should_replace_invalid_config(&loc, &err) {
                         continue; // try again
                     }
+                    #[cfg(not(windows))]
+                    let _ = err;
 
                     warn!("Config at {} was invalid - replacing with default config", loc.display());
                     if loc.exists() {
@@ -221,6 +224,7 @@ lazy_static::lazy_static! {
     };
 }
 
+#[cfg(windows)]
 pub fn current_config_path() -> &'static Path {
     CURRENT_CONFIG_PATH.get_or_init(|| default_config_paths()[0].clone())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,8 @@ use crate::{
 };
 use actix::{Actor, Addr};
 use actix_web::{web, App, HttpServer};
-use tokio::sync::{watch, RwLock};
+use std::sync::RwLock;
+use tokio::sync::watch;
 use tracing_actix_web::TracingLogger;
 
 fn init_channels() -> (watch::Receiver<manager::Event>, Addr<Manager>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ async fn init_unix_actors(
     image_store: Arc<RwLock<ImageStore>>,
 ) {
     if modules.dbus.enabled {
-        workers::dbus::start_spawning(manager, image_store, &modules.dbus.destinations)
+        workers::dbus::start_spawning(manager, image_store)
             .await
             .unwrap();
     }

--- a/src/repositories/img.rs
+++ b/src/repositories/img.rs
@@ -1,6 +1,6 @@
 use crate::image_store::ImageStore;
 use actix_web::{error, get, web, HttpResponse, Result};
-use tokio::sync::RwLock;
+use std::sync::RwLock;
 
 #[get("/{id}/{target_epoch}")]
 async fn get_image(
@@ -9,7 +9,7 @@ async fn get_image(
 ) -> Result<HttpResponse> {
     let (id, target_epoch) = path.into_inner();
     let image_store = store.into_inner();
-    let store = image_store.read().await;
+    let store = image_store.read().unwrap();
     let img = store.get(id, target_epoch);
     if let Some(img) = img {
         Ok(HttpResponse::Ok()


### PR DESCRIPTION
- Automatically discover all `org.mpris.MediaPlayer2.*` services
- Use `StoreRef` and cleanup image-store
- Disconnect when owner is cleared - we listen for when the owner is added back
- Get rid of warnings when building on Linux