### PR TITLE
refactor(gsmtc): support regex filter and adjust default for Win 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,12 @@ When releasing a new version:
 - User scripts can now wrap elements in a marquee container with `cso2.marquee.wrap(element)`. See [Album Line](https://currentsong.nerixyz.de/Customization/Theming/Examples/#album-line) for an example.
 - Added the `use-raw-data` query parameter for the overlay. If it's present in the URL, no cleanup will be performed on the client (example: `http://localhost:48457/?use-raw-data`).
 - Linux: The dbus adapter now automatically discovers all `org.mpris.MediaPlayer2.*` services. If you previously ran an instance, you need to update your config and set `modules.dbus.destinations` to `["org.mpris.MediaPlayer2.*"]`.
+- Windows: The GSMTC filters now accept a `regex`, which can be case-insensitive. This is used in the default configuration now. See [Configuration](https://currentsong.nerixyz.de/Configuration) for the current default config.
 
 ### Fixed
 
 - Linux: Local images (`file://`) are now loaded correctly.
+- Windows: The default config now excludes Chrome and Firefox on Windows 11 correctly.
 
 ## [v0.1.0-alpha.13] - 2024-06-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,6 +610,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "mpris-dbus",
+ "regex",
  "serde",
  "serde_json",
  "static-files",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ tracing-actix = "0.4"
 tracing-appender = "0.2"
 url = "2.5.4"
 fast-glob = "0.4.5"
+regex = "1.11.1"
 
 [target.'cfg(windows)'.dependencies]
 win-gsmtc = { path = "lib/win-gsmtc" }

--- a/docs/src/Configuration.md
+++ b/docs/src/Configuration.md
@@ -15,7 +15,7 @@ enabled = true
 
 [modules.gsmtc.filter]
 mode = "Exclude"
-items = ["chrome.exe", "msedge.exe", "firefox.exe"]
+regex = '(?i)(?:firefox|chrome|msedge|308046B0AF4A39CB|6F193CCC56814779)(?:\.exe)?'
 
 # DBus is Unix only
 [modules.dbus]
@@ -74,7 +74,7 @@ three modes: `Disabled`,`Include`, and `Exclude`:
     mode = "Disabled"
     ```
 
-- `Include` will only include applications listed in `items`. For example, only
+- `Include` will only include applications listed in `items` or any that match `regex`. For example, only
   include Spotify:
 
     ```toml
@@ -85,7 +85,7 @@ three modes: `Disabled`,`Include`, and `Exclude`:
 
     1. Notice the capital 'S', the filter is case-sensitive.
 
-- `Exclude` will include everything, except applications listed in `items`. For
+- `Exclude` will include everything, except applications listed in `items` or any that match `regex`. For
   example, don't include firefox:
 
     ```toml
@@ -94,9 +94,19 @@ three modes: `Disabled`,`Include`, and `Exclude`:
     items = ["firefox.exe"]
     ```
 
+    Alternatively, you can specify a `regex`:
+
+    ```toml
+    [modules.gsmtc.filter]
+    mode = "Exclude"
+    regex = "^firefox.exe$" # (1)!
+    ```
+
+    1. You can prepend the regex with `(?i)` to make it case-insensitive.
+
 <!-- prettier-ignore -->
 !!! note
-    Both lists are **case-sensitive**. <br/>
+    `items` is **case-sensitive**. <br/>
     You can see the application name in the _Task Manager_ by right-clicking and selecting _Properties_.
 
 ### `is_enabled`

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,9 @@
-use crate::{cfg_unix, cfg_windows};
+#[cfg(windows)]
+use crate::workers::gsmtc::GsmtcConfig;
+use crate::{
+    cfg_unix,
+    utilities::serde::{bool_false, bool_true},
+};
 use serde::{Deserialize, Serialize};
 use std::{
     fs,
@@ -60,16 +65,6 @@ fn default_custom_script_path() -> String {
     "user.js".to_string()
 }
 
-#[inline]
-fn bool_true() -> bool {
-    true
-}
-
-#[inline]
-fn bool_false() -> bool {
-    false
-}
-
 #[derive(Deserialize, Serialize, Debug, Default, Clone)]
 #[serde(default)]
 pub struct ModuleConfig {
@@ -108,55 +103,6 @@ impl Default for FileOutputConfig {
             enabled: false,
             path: default_file_path(),
             format: default_format(),
-        }
-    }
-}
-
-cfg_windows! {
-    use std::collections::HashSet;
-
-    #[derive(Deserialize, Serialize, Debug, Clone)]
-    #[serde(default)]
-    pub struct GsmtcConfig {
-        #[serde(default = "bool_true")]
-        pub enabled: bool,
-        pub filter: GsmtcFilter,
-    }
-
-    impl Default for GsmtcConfig {
-        fn default() -> Self {
-            Self {
-                enabled: true,
-                filter: GsmtcFilter::default(),
-            }
-        }
-    }
-
-    #[derive(Deserialize, Serialize, Debug, Clone)]
-    #[serde(tag = "mode", content = "items")]
-    pub enum GsmtcFilter {
-        Disabled,
-        Include(HashSet<String>),
-        Exclude(HashSet<String>),
-    }
-
-    impl Default for GsmtcFilter {
-        fn default() -> Self {
-            let mut set = HashSet::new();
-            set.insert("firefox.exe".into());
-            set.insert("chrome.exe".into());
-            set.insert("msedge.exe".into());
-            Self::Exclude(set)
-        }
-    }
-
-    impl GsmtcFilter {
-        pub fn pass_filter(&self, source_model_id: &str) -> bool {
-            match self {
-                GsmtcFilter::Disabled => true,
-                GsmtcFilter::Include(include) => include.contains(source_model_id),
-                GsmtcFilter::Exclude(exclude) => !exclude.contains(source_model_id),
-            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,7 @@
-#![cfg_attr(feature = "win32-executable", windows_subsystem = "windows")]
+#![cfg_attr(
+    all(feature = "win32-executable", not(test)),
+    windows_subsystem = "windows"
+)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
 #![allow(clippy::module_name_repetitions)]

--- a/src/utilities/mod.rs
+++ b/src/utilities/mod.rs
@@ -1,2 +1,3 @@
 pub mod format_string;
+pub mod serde;
 pub mod websockets;

--- a/src/utilities/serde.rs
+++ b/src/utilities/serde.rs
@@ -1,0 +1,39 @@
+use regex::Regex;
+use tracing::error;
+
+#[inline]
+pub fn bool_true() -> bool {
+    true
+}
+
+#[inline]
+pub fn bool_false() -> bool {
+    false
+}
+
+pub fn serialize_re<S: serde::Serializer>(re: &Regex, s: S) -> Result<S::Ok, S::Error> {
+    s.serialize_str(re.as_str())
+}
+
+pub fn deserialize_re<'de, D: serde::Deserializer<'de>>(de: D) -> Result<Regex, D::Error> {
+    struct Vis;
+    impl<'de> serde::de::Visitor<'de> for Vis {
+        type Value = Regex;
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(Regex::new(v).unwrap_or_else(|e| {
+                error!(error = %e, "Failed to parse regex - defaulting to empty regex");
+                Regex::new("").unwrap()
+            }))
+        }
+
+        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(f, "a regex")
+        }
+    }
+
+    de.deserialize_str(Vis)
+}

--- a/src/workers/gsmtc.rs
+++ b/src/workers/gsmtc.rs
@@ -3,15 +3,87 @@ use crate::{
     config::CONFIG,
     image_store::{ImageStore, SlotRef},
     model::{AlbumInfo, ImageInfo, InternalImage, ModuleState, PlayInfo, TimelineInfo},
+    utilities::serde::{bool_true, deserialize_re, serialize_re},
 };
 use ::gsmtc::{ManagerEvent, SessionManager, SessionUpdateEvent};
 use actix::Addr;
 use anyhow::Result as AnyResult;
-use futures::future;
 use gsmtc::{Image, PlaybackStatus, SessionModel};
+use serde::{Deserialize, Serialize};
 use std::sync::{Arc, RwLock};
 use tokio::sync::mpsc;
 use tracing::{event, span, Instrument, Level};
+
+use regex::Regex;
+use std::collections::HashSet;
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(default)]
+pub struct GsmtcConfig {
+    #[serde(default = "bool_true")]
+    pub enabled: bool,
+    pub filter: GsmtcFilter,
+}
+
+impl Default for GsmtcConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            filter: GsmtcFilter::default(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "mode")]
+pub enum GsmtcFilter {
+    Include(GsmtcFilterData),
+    Exclude(GsmtcFilterData),
+    Disabled,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum GsmtcFilterData {
+    Items {
+        items: HashSet<String>,
+    },
+    Regex {
+        #[serde(serialize_with = "serialize_re", deserialize_with = "deserialize_re")]
+        regex: Regex,
+    },
+}
+
+impl Default for GsmtcFilter {
+    fn default() -> Self {
+        Self::Exclude(GsmtcFilterData::Regex {
+            // the funny numbers are Firefox Desktop and Firefox Nightly
+            regex: Regex::new(
+                "(?i)(?:firefox|chrome|msedge|308046B0AF4A39CB|6F193CCC56814779)(?:\\.exe)?",
+            )
+            .unwrap(),
+        })
+    }
+}
+
+impl GsmtcFilter {
+    pub fn pass_filter(&self, source_model_id: &str) -> bool {
+        match self {
+            GsmtcFilter::Include(data) => data.matches(source_model_id),
+            GsmtcFilter::Exclude(data) => !data.matches(source_model_id),
+            GsmtcFilter::Disabled => true,
+        }
+    }
+}
+
+impl GsmtcFilterData {
+    pub fn matches(&self, source_model_id: &str) -> bool {
+        match self {
+            GsmtcFilterData::Items { items } => items.contains(source_model_id),
+            GsmtcFilterData::Regex { regex } => regex.is_match(source_model_id),
+        }
+    }
+}
 
 #[derive(Debug)]
 struct GsmtcWorker {
@@ -163,5 +235,153 @@ fn convert_model(from: SessionModel, image: Option<ImageInfo>) -> ModuleState {
                 }),
         }),
         _ => ModuleState::Paused,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_filter() {
+        let filter = GsmtcFilter::default();
+        let good = ["Nightly", "spotify", "VLC", "Foobar"];
+        let bad = [
+            "Chrome",
+            "MSEdge",
+            "chrome",
+            "chrome.exe",
+            "firefox.exe",
+            "MSEdge.exe",
+            "308046B0AF4A39CB",
+            "6F193CCC56814779",
+        ];
+
+        for source in good {
+            assert!(filter.pass_filter(source), "source={source}")
+        }
+        for source in bad {
+            assert!(!filter.pass_filter(source), "source={source}")
+        }
+    }
+
+    #[test]
+    fn include_strings() {
+        let filter = GsmtcFilter::Include(GsmtcFilterData::Items {
+            items: HashSet::from_iter(["foo".to_owned(), "bar".to_owned(), "baz".to_owned()]),
+        });
+        let good = ["foo", "bar", "baz"];
+        let bad = ["Foo", "fo", "oo", "foob", "BAR", "", "something", "else"];
+
+        for source in good {
+            assert!(filter.pass_filter(source), "source={source}")
+        }
+        for source in bad {
+            assert!(!filter.pass_filter(source), "source={source}")
+        }
+    }
+
+    #[test]
+    fn exclude_strings() {
+        let filter = GsmtcFilter::Exclude(GsmtcFilterData::Items {
+            items: HashSet::from_iter(["foo".to_owned(), "bar".to_owned(), "baz".to_owned()]),
+        });
+        let good = ["Foo", "fo", "oo", "foob", "BAR", "", "something", "else"];
+        let bad = ["foo", "bar", "baz"];
+
+        for source in good {
+            assert!(filter.pass_filter(source), "source={source}")
+        }
+        for source in bad {
+            assert!(!filter.pass_filter(source), "source={source}")
+        }
+    }
+
+    #[test]
+    fn disabled_filter() {
+        let filter = GsmtcFilter::Disabled;
+        assert!(filter.pass_filter("foo"));
+        assert!(filter.pass_filter(""));
+        assert!(filter.pass_filter("Chrome"));
+        assert!(filter.pass_filter("firefox.exe"));
+    }
+
+    #[test]
+    fn filter_toml() {
+        let old_default = r#"
+        mode = "Exclude"
+        items = ["firefox.exe", "chrome.exe", "msedge.exe"]
+        "#;
+        match toml::from_str::<GsmtcFilter>(old_default).unwrap() {
+            GsmtcFilter::Exclude(GsmtcFilterData::Items { items }) => {
+                assert_eq!(
+                    items,
+                    HashSet::from_iter([
+                        "firefox.exe".to_owned(),
+                        "chrome.exe".to_owned(),
+                        "msedge.exe".to_owned()
+                    ])
+                );
+            }
+            x => assert!(false, "got={x:?}"),
+        }
+
+        let default = r#"
+        mode = "Exclude"
+        regex = "(?i)(?:firefox|chrome|msedge|308046B0AF4A39CB|6F193CCC56814779)(?:\\.exe)?"
+        "#;
+        match toml::from_str::<GsmtcFilter>(default).unwrap() {
+            GsmtcFilter::Exclude(GsmtcFilterData::Regex { regex }) => {
+                assert_eq!(
+                    regex.as_str(),
+                    "(?i)(?:firefox|chrome|msedge|308046B0AF4A39CB|6F193CCC56814779)(?:\\.exe)?"
+                );
+            }
+            x => assert!(false, "got={x:?}"),
+        }
+
+        let include_str = r#"
+        mode = "Include"
+        items = ["foo", "bar"]
+        "#;
+        match toml::from_str::<GsmtcFilter>(include_str).unwrap() {
+            GsmtcFilter::Include(GsmtcFilterData::Items { items }) => {
+                assert_eq!(
+                    items,
+                    HashSet::from_iter(["foo".to_owned(), "bar".to_owned(),])
+                );
+            }
+            x => assert!(false, "got={x:?}"),
+        }
+
+        let include_re = r#"
+        mode = "Include"
+        regex = "foo"
+        "#;
+        match toml::from_str::<GsmtcFilter>(include_re).unwrap() {
+            GsmtcFilter::Include(GsmtcFilterData::Regex { regex }) => {
+                assert_eq!(regex.as_str(), "foo");
+            }
+            x => assert!(false, "got={x:?}"),
+        }
+
+        let disabled = r#"
+        mode = "Disabled"
+        "#;
+        assert!(matches!(
+            toml::from_str::<GsmtcFilter>(disabled),
+            Ok(GsmtcFilter::Disabled)
+        ));
+
+        let bad_re = r#"
+        mode = "Include"
+        regex = "("
+        "#;
+        match toml::from_str::<GsmtcFilter>(bad_re).unwrap() {
+            GsmtcFilter::Include(GsmtcFilterData::Regex { regex }) => {
+                assert_eq!(regex.as_str(), "");
+            }
+            x => assert!(false, "got={x:?}"),
+        }
     }
 }


### PR DESCRIPTION
Mentioned in https://github.com/Nerixyz/current-song2/issues/586#issuecomment-2984422665 - Windows 11 made some changes to GSMTC where it doesn't use the executable name anymore.